### PR TITLE
Handle user provisioning better

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,14 @@
+## New Features
+
+- Provisioning should work better now, since there is a daemon
+  process watching the box and "patching things up"
+- Accounts that were built by previous jumpbox manifests, but are
+  not currently in the manifest, will be disabled, and their home
+  directories renamed.  This allows administrators to manage
+  account lifecycles more easily.
+- A new `jumpbox.delete` property allows accounts to be deleted
+  from the jumpbox, but only those that had been provisioned by
+  the manifest.
 
 ##### spruce
 Bumped spruce to v1.8.2

--- a/jobs/jumpbox/monit
+++ b/jobs/jumpbox/monit
@@ -1,4 +1,5 @@
-check file jumpbox path /var/vcap/sys/run/.jumpbox_test
+check process watcher
+  with pidfile /var/vcap/sys/run/jumpbox/watcher.pid
   start program "/var/vcap/jobs/jumpbox/bin/jumpbox_ctl start"
   stop program "/var/vcap/jobs/jumpbox/bin/jumpbox_ctl stop"
   group vcap

--- a/jobs/jumpbox/spec
+++ b/jobs/jumpbox/spec
@@ -6,6 +6,7 @@ packages:
 
 templates:
   bin/jumpbox_ctl: bin/jumpbox_ctl
+  bin/watcher:     bin/watcher
   env:             env
 
 properties:
@@ -24,7 +25,6 @@ properties:
       - name: jhunt
         shell: /bin/bash
         env: https://github.com/jhunt/devbox-env.git  # specifies a git environment to clone
-        setup_script: /path/to/setup/script           # runs a script as the user, after cloning the above repo
         ssh_keys:
           - ssh-rsa AAAAB3NzaC1yabcd
           - ssh-rsa AAAAB3NzaC1y1234
@@ -35,3 +35,10 @@ properties:
       Additional environment variables to set for all users, as well as the start up scripts.
       This can be used for setting site-wide HTTP proxy configuration.
       Specified as a map of NAME: VALUE
+
+  jumpbox.delete:
+    default: []
+    description: |-
+      A list of users to delete, specified via account name.
+      By default, users that are removed from the BOSH deployment manifest will be deactivated
+      on the jumpbox deployment, but their files will be retained for reference / forensics.

--- a/jobs/jumpbox/templates/bin/jumpbox_ctl
+++ b/jobs/jumpbox/templates/bin/jumpbox_ctl
@@ -5,127 +5,29 @@ log() {
   echo >&2 "[$(date +'%Y%m%d %HH%MM.%SS')] jumpbox/setup[$$]: " $*
 }
 
-global_go=/usr/local/go
-
-newuser() {
-  user=$1         ; shift
-  shell=$1        ; shift
-  repo=$1         ; shift
-  setup_script=$1 ; shift
-
-  home="/var/vcap/store/jumpbox/home/${user}"
-  [ -z ${shell} ] && shell="/bin/bash"
-
-  log "Ensuring non-root users are allowed to ping"
-  chmod u+s /bin/ping
-
-  log "Setting up user ${user}"
-  if ! grep -q "^${user}:" /etc/passwd; then
-    log "User ${user} does not exist; adding"
-    /usr/sbin/useradd -m -d ${home} -s ${shell} ${user}
-  fi
-
-  log "Setting up sudoers access for ${user}"
-  if ! grep -q "^${user} " /etc/sudoers; then
-    log "Access not found; configuring ${user} with NOPASSWD:ALL access"
-    (echo; echo "${user} ALL=(ALL:ALL) NOPASSWD:ALL") >> /etc/sudoers
-    chmod 0400 /etc/sudoers
-  fi
-
-  if [[ $# -gt 0 ]]; then
-    log "Setting up ${user} SSH authorized keys"
-    mkdir -p ${home}/.ssh
-    chmod 0700 ${home}/.ssh
-    touch ${home}/.ssh/authorized_keys
-    for key in "$@"; do
-      if ! grep -q "^$key$" ${home}/.ssh/authorized_keys; then
-        echo "$key" >> ${home}/.ssh/authorized_keys
-      fi
-    done
-  fi
-  chown -R ${user} ${home}
-
-  if [[ -n "${repo}" ]]; then
-    log "Setting up ${user} environment"
-    if [[ ! -d ${home}/env ]]; then
-      log "Environment repo ${home}/env not found; cloning from upstream"
-      git clone ${repo} ${home}/env
-
-      log "Running install script from inside of ${home}/env, as ${user} with HOME=${home}"
-      (cd ${home}/env
-       export HOME=${home}
-       export USER=${user}
-       [ -x ./install ] && ./install || true)
-    fi
-  fi
-
-  log "Running setup script ('${setup_script}') from inside of ${home}/env, as ${user} with HOME=${home}"
-  (sudo -iu ${user} bash -c "[ -x ${setup_script} ] && ${setup_script} || true" )
-
-  log "Setting up golang for ${user}"
-  mkdir ${home}/go
-  cat >>${home}/.bashrc << EOF
-export GOPATH=${home}/go
-export PATH=\${PATH}:${global_go}/bin:\${GOPATH}/bin
-EOF
-
-  chown -R ${user} ${home}
-}
-
 set -e
 rm -f /etc/profile.d/jumpbox.sh
 cp /var/vcap/jobs/jumpbox/env /etc/profile.d/jumpbox.sh
 source /etc/profile.d/jumpbox.sh
+pidfile=/var/vcap/sys/run/jumpbox/watcher.pid
+watcher=/var/vcap/jobs/jumpbox/bin/watcher
+
+mkdir -p $(dirname $pidfile)
+chown vcap:vcap $(dirname $pidfile)
 
 case $1 in
-
   start)
-    log "Creating persistent home container"
-    mkdir -p /var/vcap/store/jumpbox/home
-    log "Fixing permissions on /tmp"
-    chmod 1777 /tmp
-
-    log "Installing go to ${global_go}"
-    if [[ ! -e ${global_go} ]]; then
-        ln -s /var/vcap/packages/golang ${global_go}
-    fi
-
-    log "Setting hostname to <%= p('jumpbox.hostname') %>"
-    echo "<%= p('jumpbox.hostname') %>" > /etc/hostname
-    hostname -b -F /etc/hostname
-
-    log "Setting up /etc/hosts"
-<% p('jumpbox.hosts').each do |line| %>
-    if ! grep -q '^<%= line %>$' /etc/hosts; then
-        echo "<%= line %>" >> /etc/hosts
-    fi
-<% end %>
-
-    log "Setting up sudoers to allow certain environment variables to not be reset"
-    for var in http_proxy https_proxy ftp_proxy no_proxy EDITOR; do
-    if ! grep '^Defaults env_keep' /etc/sudoers | grep -q "${var}"; then
-            echo "Defaults env_keep += \"${var}\"" >> /etc/sudoers
-        fi
-    done
-
-<% p('jumpbox.users').each do |user| %>
-# jumpbox.users[<%= user['name'] %>
-    newuser "<%= user['name'] %>" \
-        "<%= user['shell'] %>" \
-        "<%= user['env'] %>" \
-        "<%= user['setup_script'] || '/var/vcap/packages/jumpbox/setup' %>"<% if !(user['ssh_keys'] || []).empty? %> \<% end %>
-       <% (user['ssh_keys'] || []).each do |k| %> "<%= k %>"<% end %>
-<% end %>
-
-    touch /var/vcap/sys/run/.jumpbox_test
+    echo $$ > $pidfile
+    exec $watcher
     ;;
 
   stop)
-
+    kill -9 $(cat $pidfile)
+    rm -f $pidfile
     ;;
 
   *)
-    echo "Usage: jumpbox_ctl {start|stop}"
+    echo "Usage: jumpbox {start|stop}"
     ;;
 
 esac

--- a/jobs/jumpbox/templates/bin/watcher
+++ b/jobs/jumpbox/templates/bin/watcher
@@ -1,0 +1,227 @@
+#!/bin/bash
+exec </dev/null >>/var/vcap/sys/log/jumpbox.log 2>&1
+
+#
+# watcher is a small shell-daemon that regularly checks
+# the state of the jumpbox and attempts to remedy any
+# problems it sees with respect to things like sudoers
+# configuration, users, system configs, etc.
+#
+
+# Set during the first iteration of the watch loop, but
+# unset in all subsequent iterations.	This is useful for
+# providing good diagnostics for operators troubleshooting
+# the jumpbox via `monit restart`
+FIRSTRUN=1
+
+JUMPBOX_HOME=/var/vcap/store/jumpbox/home
+JUMPBOX_GO=/usr/local/go
+JUMPBOX_HOSTNAME="<%= p('jumpbox.hostname') %>"
+
+# Things that only get logged on the first run-through
+log1() {
+	if [[ $FIRSTRUN == 1 ]]; then
+		log $*
+	fi
+}
+
+# Things that only get logged on subsequent run-throughs
+logn() {
+	if [[ $FIRSTRUN != 1 ]]; then
+		log $*
+	fi
+}
+
+# Things that get logged on all run-throughs
+log() {
+	echo >&2 "[$(date +'%Y%m%d %HH%MM.%SS')] jumpbox[$$]: " $*
+}
+
+provision() {
+	local user=$1  ; shift
+	local shell=$1 ; shift
+	local repo=$1  ; shift
+	local setup=$1 ; shift
+
+	home="${JUMPBOX_HOME}/${user}"
+	[ -z ${shell} ] && shell="/bin/bash"
+
+	log1 "Setting up user ${user}"
+	if ! grep -q "^${user}:" /etc/passwd; then
+		logn "User ${user} does not exist; adding"
+		/usr/sbin/useradd -m -d ${home} -s ${shell} ${user}
+	fi
+	mkdir -p ${home}
+	/usr/sbin/usermod --expiredate -1 ${user}
+
+	log1 "Setting up sudoers access for ${user}"
+	if ! grep -q "^${user} " /etc/sudoers; then
+		logn "Access not found; configuring ${user} with NOPASSWD:ALL access"
+		(echo; echo "${user} ALL=(ALL:ALL) NOPASSWD:ALL") >> /etc/sudoers
+		chmod 0400 /etc/sudoers
+	fi
+
+	if [[ $# -gt 0 ]]; then
+		log1 "Setting up ${user} SSH authorized keys"
+		mkdir -p ${home}/.ssh
+		chmod 0700 ${home}/.ssh
+		touch ${home}/.ssh/authorized_keys
+		for key in "$@"; do
+			if ! grep -q "^$key$" ${home}/.ssh/authorized_keys; then
+				logn "Configuring new SSH authorized key for ${user}"
+				echo "$key" >> ${home}/.ssh/authorized_keys
+			fi
+		done
+	fi
+	chown -R ${user} ${home}
+
+	if [[ -n "${repo}" ]]; then
+		log1 "Setting up ${user} environment"
+		if [[ ! -d ${home}/env ]]; then
+			logn "Environment repo ${home}/env not found; cloning from upstream"
+			git clone ${repo} ${home}/env
+
+			logn "Running install script from inside of ${home}/env, as ${user} with HOME=${home}"
+			(cd ${home}/env
+			 export HOME=${home}
+			 export USER=${user}
+			 [ -x ./install ] && ./install || true)
+		fi
+	fi
+
+	if [[ ! -f ${home}/.jumpbox ]]; then
+		log1 "Running setup script ('${setup}') from inside of ${home}/env, as ${user} with HOME=${home}"
+		(sudo -iu ${user} bash -c "[ -x ${setup} ] && ${setup} || true" )
+		touch ${home}/.jumpbox
+	fi
+
+	if [[ ! -d ${home}/go ]]; then
+		log1 "Setting up Go runtime for ${user}"
+		mkdir ${home}/go
+		cat >>${home}/.bashrc << EOF
+export GOPATH=${home}/go
+export PATH=\${PATH}:${global_go}/bin:\${GOPATH}/bin
+EOF
+	fi
+
+	chown -R ${user} ${home}
+}
+
+deactivate() {
+	local user=$1
+	local today=$(date +%YMD)
+
+	local to="${JUMPBOX_HOME}/.${user}.${today}"
+	log "Deactivating user $user"
+	if [[ -d ${to} ]]; then
+		log "ERROR: Cannot move ~$user to '${to}': already exists"
+		stat $to
+		log "SKIPPING USER DEACTIVATION"
+		return
+	fi
+
+	log "Locking ${user} account (via expiration date)"
+	/usr/sbin/usermod --expiredate 1 ${user}
+	log "Moving home directory ~${user} to ${to}"
+	mv ${JUMPBOX_HOME}/${user} ${to}
+}
+
+remove() {
+	user=$1
+	home=$(getent passwd ${user} | cut -d: -f6)
+	if [[ $home == "" ]]; then
+		return
+	fi
+	if [[ $home != ${JUMPBOX_HOME}/${user} ]]; then
+		log "Cannot remove user ${user} - not provisioned by the jumpbox release..."
+		return
+	fi
+	log "Removing user ${user}"
+	log "Cleaning up old any old home directories"
+	rm -rf ${JUMPBOX_HOME}/${user}/ \
+	       ${JUMPBOX_HOME}/.${user}.*
+	log "Deleting user account from system databases"
+	/usr/sbin/userdel -r ${user}
+}
+
+while true; do
+	log1 "Setting up ${JUMPBOX_HOME} base directory"
+	if [[ ! -d ${JUMPBOX_HOME} ]]; then
+		logn "${JUMPBOX_HOME} not found; fixing"
+		mkdir -p ${JUMPBOX_HOME}
+	fi
+
+	log1 "Setting permissions on /tmp to 1777"
+	chmod 1777 /tmp
+
+	log1 "Ensuring non-root users are allowed to ping"
+	chmod u+s /bin/ping
+
+	log1 "Setting up system-wide Go runtime at ${JUMPBOX_GO}"
+	if [[ ! -e $JUMPBOX_GO ]]; then
+		logn "${JUMPBOX_GO} not linked to /var/vcap/packages/golang; fixing"
+		ln -s /var/vcap/packages/golang ${JUMPBOX_GO}
+	fi
+
+	log1 "Setting hostname to ${JUMPBOX_HOSTNAME}"
+	if [[ $(cat /etc/hostname) != ${JUMPBOX_HOSTNAME} ]]; then
+		logn "Hostname (via /etc/hostname) not set to ${JUMPBOX_HOSTNAME}; fixing"
+		echo ${JUMPBOX_HOSTNAME} > /etc/hostname
+		hostname -b -F /etc/hostname
+	fi
+
+	log1 "Seting up /etc/hosts DNS overrides"
+	if ! grep -q "^127.0.0.1 ${JUMPBOX_HOSTNAME}\$" /etc/hosts; then
+		logn "Entry '127.0.0.1 ${JUMPBOX_HOSTNAME}' not found in /etc/hosts; fixing"
+		sed -i -e 's/^127.0.0.1//' /etc/hosts
+		echo "127.0.0.1 ${JUMPBOX_HOSTNAME}" >> /etc/hosts
+	fi
+<% p('jumpbox.hosts').each do |line| %>
+	if ! grep -q '^<%= line %>$' /etc/hosts; then
+		logn "Entry '<%= line %>' not found in /etc/hosts; fixing"
+		echo "<%= line %>" >> /etc/hosts
+	fi
+<% end %>
+
+	log1 "Setting up sudoers to allow certain environment variables to pass through"
+	for var in http_proxy https_proxy ftp_proxy no_proxy EDITOR; do
+		if ! grep '^Defaults env_keep' /etc/sudoers | grep -q "${var}"; then
+			logn "Environment variable '${var}' not set to env_keep in /etc/sudoers; fixing"
+			echo "Defaults env_keep += \"${var}\"" >> /etc/sudoers
+		fi
+	done
+
+	log1 "Setting up jumpbox users"
+	declare -A users
+	pushd ${JUMPBOX_HOME} >/dev/null 2>&1
+	for user in *; do
+		# deleted users are moved to be hidden directories
+		if [[ -d ${user}/ ]]; then
+			users[$user]=1
+		fi
+	done
+	popd >/dev/null
+<% p('jumpbox.users').each do |user| %>
+	unset users["<%= user['name'] %>"]
+	# jumpbox.users[<%= user['name'] %>
+	provision "<%= user['name'] %>" \
+	          "<%= user['shell'] %>" \
+	          "<%= user['env'] %>" \
+	          "<%= user['setup_script'] || '/var/vcap/packages/jumpbox/setup' %>"<% if !(user['ssh_keys'] || []).empty? %> \<% end %>
+	          <% (user['ssh_keys'] || []).each do |k| %> "<%= k %>"<% end %>
+<% end %>
+
+<% p('jumpbox.delete', []).each do |user| %>
+	unset users["<%= user %>"]
+	remove "<%= user %>"
+<% end %>
+
+	for user in ${!users[@]}; do
+		deactivate ${user}
+	done
+
+
+	log1 "Complete.  Will verify / fix every 5 minutes"
+	FIRSTRUN=0
+	sleep 300 # try again in 5 minutes
+done

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -23,3 +23,10 @@ properties:
   jumpbox:
     env:
       FOO: BAR
+    users:
+      - name: alice
+      - name: bob
+      - name: eve
+        shell: /bin/sh
+    delete:
+      - chris


### PR DESCRIPTION
Now, instead of a one-shot job that only fires on `monit start` (and
sometimes not even reliably then), jumpbox has a watcher script that
spins on a 5m loop checking to see if it needs to "fix" things.

This commit also introduces account invalidation and removal.  To
invalidate an account, remove it from the manifest.  To delete it, add
it to the jumpbox.delete manifest property (list).

Fixes #11

cc @geofffranks - was wondering your thoughts on this.  I'm thinking we need to go a bit further, and move the per-user setup into run-once scripts inside their profiles, so that they trigger when they log in.  Otherwise, I was getting annoying delays waiting for rvm to install itself, ruby, all the gems, etc., for each user ahead of mine in the list...  But this PR is a start.
