### PR TITLE
Only recreate .repo when necessary

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,10 @@
+## Bug Fixes
+
+- The ~/.repo file is no longer constantly updated by the `watcher`
+  script. It is only updated when the contents change. This works
+  around issues when performing tar-based-backups that take longer
+  than 5 minutes, as the watcher script would update the modification/
+  creation time of files underneath tar, causing it to error.
 
 ##### cf
 Bumped cf to v6.25.0

--- a/jobs/jumpbox/templates/bin/watcher
+++ b/jobs/jumpbox/templates/bin/watcher
@@ -76,7 +76,14 @@ provision() {
 	fi
 
 	if [[ -n "${repo}" ]]; then
-		echo "${repo}" > ${home}/.repo
+		if [[ ! -f ${home}/.repo ]]; then
+			touch ${home}/.repo
+		fi
+
+		old_repo=$(cat ${home}/.repo)
+		if [[ "${repo}" != "${old_repo}" ]]; then
+			echo "${repo}" > ${home}/.repo
+		fi
 	else
 		rm -f ${home}/.repo
 	fi


### PR DESCRIPTION
Ran into issues when performing tar-based-backups that take longer
than 5 minutes, as the watcher script would update the modification/
creation time of files underneath tar, causing it to error, as the containing directory data had changed during tar