### PR TITLE
add additional GPG key for rvm

### DIFF
--- a/src/jumpbox/setup
+++ b/src/jumpbox/setup
@@ -5,7 +5,7 @@ if [[ ! -f ~/.rvmrc ]]; then
 	echo rvm_silence_path_mismatch_check_flag=1 > ~/.rvmrc
 fi
 if [[ -z "$(command -v rvm)" ]]; then
-	gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+	gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 	curl -sSL https://get.rvm.io | bash -s stable --ruby
 
 	source ~/.rvm/scripts/rvm


### PR DESCRIPTION
Recent RVM needs an additional GPG key (see https://rvm.io/), otherwise setup fails.