### PR TITLE
Don't use deprecated gem option

### DIFF
--- a/src/jumpbox/setup
+++ b/src/jumpbox/setup
@@ -16,7 +16,7 @@ fi
 
 rvm install ruby-2.4
 rvm --default use 2.4
-gem install --no-ri --no-rdoc cf-uaac
+gem install -N cf-uaac
 
 # Uninstall BOSH v1 if it is installed
 gem uninstall -aIx bosh_cli bosh-workspace


### PR DESCRIPTION
```
ruby-2.4.6 - #adjusting #shebangs for (gem irb erb ri rdoc testrb rake).
Install of ruby-2.4.6 - #complete
Ruby was built without documentation, to build it run: rvm docs generate-ri
Using /u/pfmanager/.rvm/gems/ruby-2.4.6
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-ri
```

`-N(--no-document)` instead `--no-ri --no-rdoc`.