### PR TITLE
Add further clis to ci

### DIFF
--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -47,6 +47,7 @@ groups:
     - bosh-backup-and-restore
     - bosh-cli
     - credhub-cli
+    - fly
 
 jobs:
   - name: genesis # {{{
@@ -575,6 +576,71 @@ jobs:
           ok:      no
           link:    (( grab meta.shout.links.build ))
    # }}}
+  - name: fly # {{{
+    public: true
+    plan:
+    - in_parallel:
+      - { get: git }
+      - { get: concourse, trigger: true }
+    - task: update-fly
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: (( grab meta.image.name ))
+            tag:        (( grab meta.image.tag ))
+        inputs:
+        - name: git
+        - name: concourse
+        outputs:
+        - name: pushme
+        run:
+          path: ./git/ci/scripts/update-blob
+        params:
+          REPO_ROOT:        git
+          REPO_OUT:         pushme
+          BLOB_DIR:         concourse
+          BLOB_NAME:        fly
+          BLOB_BINARY:      fly-*-linux-amd64.tgz # Think .tgz is not working well here
+          BLOB_DESTINATION: jumpbox/bins/fly
+          BLOB_CLEANUP:     jumpbox/bins/fly
+          AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))
+          AWS_SECRET_KEY:   (( grab meta.aws.secret_key ))
+          BRANCH:           (( grab meta.github.branch ))
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+    - put: git
+      params:
+        rebase: true
+        repository: pushme/git
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+   # }}}
 
 resources:
   - name: genesis # {{{
@@ -631,5 +697,12 @@ resources:
     source:
       user: cloudfoundry-incubator
       repository: credhub-cli
+      access_token: (( grab meta.github.access_token ))
+  # }}}
+  - name: fly # {{{
+    type: github-release
+    source:
+      user: concourse
+      repository: concourse
       access_token: (( grab meta.github.access_token ))
   # }}}

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -540,7 +540,6 @@ jobs:
           REPO_ROOT:        git
           REPO_OUT:         pushme
           RELEASE_DIR:      credhub-cli
-          BLOB_SOURCE:      https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/%s/credhub-linux-%s.tgz
           BLOB_DIR:         credhub
           BLOB_NAME:        credhub
           BLOB_BINARY:      credhub
@@ -611,7 +610,6 @@ jobs:
           REPO_ROOT:        git
           REPO_OUT:         pushme
           BLOB_DIR:         concourse
-          BLOB_SOURCE:      https://github.com/concourse/concourse/releases/download/%s/fly-%s-linux-amd64.tgz # the file name does not include the v of the version name, can we get rid of that here? 
           BLOB_NAME:        fly
           BLOB_BINARY:      fly
           BLOB_DESTINATION: jumpbox/bins/fly

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -516,7 +516,11 @@ jobs:
     plan:
     - in_parallel:
       - { get: git }
-      - { get: credhub-cli, trigger: true }
+      - get: credhub-cli
+        trigger: true
+        params:
+          globs:
+          - credhub-linux-*.tgz
     - task: update-credhub-cli
       config:
         platform: linux
@@ -583,7 +587,11 @@ jobs:
     plan:
     - in_parallel:
       - { get: git }
-      - { get: concourse, trigger: true }
+      - get: concourse
+        trigger: true
+        params:
+          globs:
+          - fly-*-linux-amd64.tgz
     - task: update-fly
       config:
         platform: linux

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -44,6 +44,7 @@ groups:
     - esuf
     - cf
     - cloudfoundry-utils
+    - bosh-backup-and-restore
 
 jobs:
   - name: genesis # {{{
@@ -377,6 +378,71 @@ jobs:
           ok:      no
           link:    (( grab meta.shout.links.build ))
    # }}}
+  - name: bosh-backup-and-restore # {{{
+    public: true
+    plan:
+    - in_parallel:
+      - { get: git }
+      - { get: bosh-backup-and-restore, trigger: true }
+    - task: update-bosh-backup-and-restore
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: (( grab meta.image.name ))
+            tag:        (( grab meta.image.tag ))
+        inputs:
+        - name: git
+        - name: bosh-backup-and-restore
+        outputs:
+        - name: pushme
+        run:
+          path: ./git/ci/scripts/update-blob
+        params:
+          REPO_ROOT:        git
+          REPO_OUT:         pushme
+          BLOB_DIR:         bosh-backup-and-restore
+          BLOB_NAME:        bbr
+          BLOB_BINARY:      bbr-*-linux-amd64
+          BLOB_DESTINATION: jumpbox/bins/bbr
+          BLOB_CLEANUP:     jumpbox/bins/bbr
+          AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))
+          AWS_SECRET_KEY:   (( grab meta.aws.secret_key ))
+          BRANCH:           (( grab meta.github.branch ))
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+    - put: git
+      params:
+        rebase: true
+        repository: pushme/git
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+   # }}}
 
 resources:
   - name: genesis # {{{
@@ -412,5 +478,12 @@ resources:
     source:
       user: cloudfoundry-community
       repository: cloudfoundry-utils
+      access_token: (( grab meta.github.access_token ))
+  # }}}
+  - name: bosh-backup-and-restore # {{{
+    type: github-release
+    source:
+      user: cloudfoundry-incubator
+      repository: bosh-backup-and-restore
       access_token: (( grab meta.github.access_token ))
   # }}}

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -537,8 +537,8 @@ jobs:
           REPO_OUT:         pushme
           RELEASE_DIR:      credhub-cli
           BLOB_SOURCE:      https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/%s/credhub-linux-%s.tgz
-          BLOB_DIR:         credhub-cli
-          BLOB_NAME:        credhub-cli
+          BLOB_DIR:         credhub
+          BLOB_NAME:        credhub
           BLOB_BINARY:      credhub
           BLOB_DESTINATION: jumpbox/bins/credhub
           BLOB_CLEANUP:     jumpbox/bins/credhub
@@ -603,8 +603,9 @@ jobs:
           REPO_ROOT:        git
           REPO_OUT:         pushme
           BLOB_DIR:         concourse
+          BLOB_SOURCE:      https://github.com/concourse/concourse/releases/download/%s/fly-%s-linux-amd64.tgz # the file name does not include the v of the version name, can we get rid of that here? 
           BLOB_NAME:        fly
-          BLOB_BINARY:      fly-*-linux-amd64.tgz # Think .tgz is not working well here
+          BLOB_BINARY:      fly
           BLOB_DESTINATION: jumpbox/bins/fly
           BLOB_CLEANUP:     jumpbox/bins/fly
           AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -535,9 +535,11 @@ jobs:
         params:
           REPO_ROOT:        git
           REPO_OUT:         pushme
+          RELEASE_DIR:      credhub-cli
+          BLOB_SOURCE:      https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/%s/credhub-linux-%s.tgz
           BLOB_DIR:         credhub-cli
           BLOB_NAME:        credhub-cli
-          BLOB_BINARY:      credhub-linux-*.tgz # Think .tgz is not working well here
+          BLOB_BINARY:      credhub
           BLOB_DESTINATION: jumpbox/bins/credhub
           BLOB_CLEANUP:     jumpbox/bins/credhub
           AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -46,6 +46,7 @@ groups:
     - cloudfoundry-utils
     - bosh-backup-and-restore
     - bosh-cli
+    - credhub-cli
 
 jobs:
   - name: genesis # {{{
@@ -509,6 +510,71 @@ jobs:
           ok:      no
           link:    (( grab meta.shout.links.build ))
    # }}}
+  - name: credhub-cli # {{{
+    public: true
+    plan:
+    - in_parallel:
+      - { get: git }
+      - { get: credhub-cli, trigger: true }
+    - task: update-credhub-cli
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: (( grab meta.image.name ))
+            tag:        (( grab meta.image.tag ))
+        inputs:
+        - name: git
+        - name: credhub-cli
+        outputs:
+        - name: pushme
+        run:
+          path: ./git/ci/scripts/update-blob
+        params:
+          REPO_ROOT:        git
+          REPO_OUT:         pushme
+          BLOB_DIR:         credhub-cli
+          BLOB_NAME:        credhub-cli
+          BLOB_BINARY:      credhub-linux-*.tgz # Think .tgz is not working well here
+          BLOB_DESTINATION: jumpbox/bins/credhub
+          BLOB_CLEANUP:     jumpbox/bins/credhub
+          AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))
+          AWS_SECRET_KEY:   (( grab meta.aws.secret_key ))
+          BRANCH:           (( grab meta.github.branch ))
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+    - put: git
+      params:
+        rebase: true
+        repository: pushme/git
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+   # }}}
 
 resources:
   - name: genesis # {{{
@@ -558,5 +624,12 @@ resources:
     source:
       user: cloudfoundry
       repository: bosh-cli
+      access_token: (( grab meta.github.access_token ))
+  # }}}
+  - name: credhub-cli # {{{
+    type: github-release
+    source:
+      user: cloudfoundry-incubator
+      repository: credhub-cli
       access_token: (( grab meta.github.access_token ))
   # }}}

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -45,6 +45,7 @@ groups:
     - cf
     - cloudfoundry-utils
     - bosh-backup-and-restore
+    - bosh-cli
 
 jobs:
   - name: genesis # {{{
@@ -443,6 +444,71 @@ jobs:
           ok:      no
           link:    (( grab meta.shout.links.build ))
    # }}}
+  - name: bosh-cli # {{{
+    public: true
+    plan:
+    - in_parallel:
+      - { get: git }
+      - { get: bosh-cli, trigger: true }
+    - task: update-bosh-cli
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: (( grab meta.image.name ))
+            tag:        (( grab meta.image.tag ))
+        inputs:
+        - name: git
+        - name: bosh-cli
+        outputs:
+        - name: pushme
+        run:
+          path: ./git/ci/scripts/update-blob
+        params:
+          REPO_ROOT:        git
+          REPO_OUT:         pushme
+          BLOB_DIR:         bosh-cli
+          BLOB_NAME:        bosh-cli
+          BLOB_BINARY:      bosh-cli-*-linux-amd64
+          BLOB_DESTINATION: jumpbox/bins/bosh
+          BLOB_CLEANUP:     jumpbox/bins/bosh
+          AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))
+          AWS_SECRET_KEY:   (( grab meta.aws.secret_key ))
+          BRANCH:           (( grab meta.github.branch ))
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+    - put: git
+      params:
+        rebase: true
+        repository: pushme/git
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+   # }}}
 
 resources:
   - name: genesis # {{{
@@ -485,5 +551,12 @@ resources:
     source:
       user: cloudfoundry-incubator
       repository: bosh-backup-and-restore
+      access_token: (( grab meta.github.access_token ))
+  # }}}
+  - name: bosh-cli # {{{
+    type: github-release
+    source:
+      user: cloudfoundry
+      repository: bosh-cli
       access_token: (( grab meta.github.access_token ))
   # }}}


### PR DESCRIPTION
Added some more CLIs to the CI to auto-bump them in the future.

Currently I have two issues for fly + credhub the CLIs gets provided as a .tgz (that means `BLOB_BINARY` is like xyz.tgz) . I did not see an example in the existing code if such a case can be handled except for maybe `cf`, as `cf` gets triggered by the git release but downloads the binary from an external URL. 

I think for credhub/fly a similar approach needs to be taken. @jhunt could you might share some light here? 

Thank you. 

I will adjust the current branch as needed. 