### PR TITLE
Declare Users variable as Global

### DIFF
--- a/jobs/jumpbox/templates/bin/watcher
+++ b/jobs/jumpbox/templates/bin/watcher
@@ -238,7 +238,7 @@ EOF
 	fi
 
 	log1 "Setting up jumpbox users"
-	declare -A users
+	declare -Ag users
 	pushd ${JUMPBOX_HOME} >/dev/null 2>&1
 	for user in *; do
 		# deleted users are moved to be hidden directories


### PR DESCRIPTION
Re-declaring does not clear an associative array...if we unset it, and then declare it again, it will only be local to the function.  Changing it to global fixes this.

Fixes #85 
