### PR TITLE
Make correct permissions of new authorized_keys before replacing

### DIFF
--- a/jobs/jumpbox/templates/bin/watcher
+++ b/jobs/jumpbox/templates/bin/watcher
@@ -71,11 +71,12 @@ provision() {
     mkdir -p ${home}/.ssh
     chmod 0700 ${home}/.ssh
     touch ${home}/.ssh/authorized_keys_new
+    chmod 0600 ${home}/.ssh/authorized_keys_new
+    chown ${user}: ${home}/.ssh/authorized_keys_new
     for key in "$@"; do
       echo "$key" >> ${home}/.ssh/authorized_keys_new
     done
     mv ${home}/.ssh/authorized_keys_new ${home}/.ssh/authorized_keys
-    chmod 0600 ${home}/.ssh/authorized_keys
   fi
 
   if [[ -n "${repo}" ]]; then


### PR DESCRIPTION
We have some environments where the permission of the authorized_keys file was <user>:root or even root:root after each watcher run. This made our connections not working.

This change makes sure the new authorized_keys file has the correct permission before it is moved into place, which resolves the issue.