### PR TITLE
Fix sshd configuration

### DIFF
--- a/jobs/jumpbox/templates/bin/watcher
+++ b/jobs/jumpbox/templates/bin/watcher
@@ -35,7 +35,7 @@ sshd_configure() {
   key=$1 ; value=$2
   if ! grep -q '^${key} ${value}' /etc/ssh/sshd_config; then
     log1 "/etc/ssh/sshd_config => ${key} ${value}"
-    sed -i -e '/^${key}/d' /etc/ssh/sshd_config
+    sed -i -e "/^${key}/d" /etc/ssh/sshd_config
     echo "${key} ${value}" >> /etc/ssh/sshd_config
   fi
 }
@@ -203,8 +203,8 @@ EOF
 <% end %>
 
   sshd_configure PasswordAuthentication <%= p('jumpbox.ssh.password_auth') == "true" ? "yes" : "no" %>
-  sshd_configure AllowAgentForwarding <%= p('jumpbox.ssh.allow_agent_forwarding') == "true" ? "yes" : "no" -%>
-  sshd_configure AllowTcpForwarding <%= p('jumpbox.ssh.allow_tcp_forwarding') == "true" ? "yes" : "no" -%>
+  sshd_configure AllowAgentForwarding <%= p('jumpbox.ssh.allow_agent_forwarding') ? "yes" : "no" %>
+  sshd_configure AllowTcpForwarding <%= p('jumpbox.ssh.allow_tcp_forwarding') ? "yes" : "no" %>
   systemctl restart sshd.service # We assume bionic or later
 
   log1 "Setting up sudoers to allow certain environment variables to pass through"


### PR DESCRIPTION
This partially reverts https://github.com/cloudfoundry-community/jumpbox-boshrelease/commit/a8b199e0818bb6349b847c2775dcf7cc4ac23d1a because p() returns a boolean in case the property is true or false which is not equal to the string "true".

The ERB syntax to remove the line end was removed because it writes `sshd_configure AllowAgentForwarding [...]` and the following to two lines into one single line, which made the last two basically arguments of the sshd_configure function and hence not working.

Also, the removal of the overwritten configuration statements in sshd_config was not working because the key was not interpolated in the sed expression.