### PR TITLE
Fix erroneous path

### DIFF
--- a/packages/jumpbox/packaging
+++ b/packages/jumpbox/packaging
@@ -32,7 +32,7 @@ n=$((n + 1))
 # https://www.kernel.org/pub/software/scm/git
 # https://www.kernel.org/pub/software/scm/git/git-2.35.7.tar.gz
 (tar -xzvf jumpbox/git-2.35.7.tar.gz
- cd git-2.35.1
+ cd git-2.35.7
  ./configure --prefix=${BOSH_INSTALL_TARGET}
  make -j${CPUS} all
  make install) &


### PR DESCRIPTION
The new git tgz is unpacked under a different folder, on update this seemed to have slipped. 

See: https://github.com/cloudfoundry-community/jumpbox-boshrelease/issues/95