### PR TITLE
Make Release Jammy compatible/ Switch manifest to Jammy

### DIFF
--- a/ci/manifest.yml
+++ b/ci/manifest.yml
@@ -34,7 +34,7 @@ update:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 releases:

--- a/manifests/jumpbox.yml
+++ b/manifests/jumpbox.yml
@@ -24,7 +24,7 @@ update:
 
 stemcells:
 - alias:   default
-  os:      ubuntu-bionic
+  os:      ubuntu-jammy
   version: latest
 
 releases:

--- a/packages/jumpbox/packaging
+++ b/packages/jumpbox/packaging
@@ -82,7 +82,7 @@ n=$((n + 1))
 # https://ftp.gnu.org/gnu/wget/wget-1.21.3.tar.gz
 (tar -xzvf jumpbox/wget-1.21.3.tar.gz
  cd wget-1.21.3
- ./configure --prefix=${BOSH_INSTALL_TARGET} --with-ssl=openssl
+ OPENSSL_CFLAGS=" " OPENSSL_LIBS="-lssl -lcrypto" ./configure --prefix=${BOSH_INSTALL_TARGET} --with-ssl=openssl
  make -j${CPUS}
  make install) &
 n=$((n + 1))


### PR DESCRIPTION
Adding the flags to the configure fixes the compilation issues for wget on jammy. With the flags it works for both Jammy and Bionic. 