### PR TITLE
Fix logs on jumpbox

### DIFF
--- a/jobs/jumpbox/templates/bin/watcher
+++ b/jobs/jumpbox/templates/bin/watcher
@@ -1,5 +1,5 @@
 #!/bin/bash
-exec </dev/null >>/var/vcap/sys/log/jumpbox.log 2>&1
+exec </dev/null >>/var/vcap/sys/log/jumpbox/jumpbox.log 2>&1
 umask 022
 
 #

--- a/jobs/jumpbox/templates/bin/watcher
+++ b/jobs/jumpbox/templates/bin/watcher
@@ -165,8 +165,8 @@ while true; do
   if [[ ${WATCHER_MTIME_NOW} -gt ${WATCHER_MTIME_START} ]]; then
     exec ${WATCHER}
   fi
-
-  if [[ -d ${JUMPBOX_ETC} ]]; then cp -a ${JUMPBOX_ETC}/* /etc/ ; fi
+  #Ignore on first run becasue that can cause issues when the stemcell changes userids
+  if [[ -d ${JUMPBOX_ETC} && $FIRSTRUN -eq 0 ]]; then cp -a ${JUMPBOX_ETC}/* /etc/ ; fi
 
   log1 "Setting up jumpbox banner"
   if [[ -d /etc/update-motd.d && ! -f /etc/update-motd.d/99-banner ]]; then


### PR DESCRIPTION
We recently noticed that jumpbox broke the Log rotation on our inceptions. We traced it back to the fact that the stemcells at some point started to use syslog with UID 104, and assigned the /var/log logs to that UID. 

The problem was that the jumpbox is storing a copy of the /etc/passwd on the persistent store and loads it at the start of each run. WHile that prevents someone manually using useradd in between runs, it breaks in this case, since it overwrites the stemcells default users on first run. 

This change disables the copy of the passwd from Persistent store on the First run of the watcher, so the userlist does not cause issues on the stemcell side and is freshly built with the users given to the Jumpbox boshrelease.