### PR TITLE
Fix s3cmd install landing outside package bin

### DIFF
--- a/jobs/inventory/templates/bin/run
+++ b/jobs/inventory/templates/bin/run
@@ -7,12 +7,14 @@ EXITSTATUS=0
 check() {
 	name=$1
 	echo -en "Checking \e[1;35m${name}\e[0m... "
-	if ! $* >/dev/null 2>&1; then
+	if output=$("$@" 2>&1); then
+		echo -e "\e[1;32mOK\e[0m"
+	else
 		echo -e "\e[1;31mFAILED!\e[0m"
 		EXITSTATUS=1
-	else
-		echo -e "\e[1;32mOK\e[0m"
-		$* 2>&1 | sed -e 's/^/  /g'
+	fi
+	if [[ -n ${output} ]]; then
+		echo "${output}" | sed -e 's/^/  /g'
 	fi
 	echo
 }

--- a/packages/jumpbox/packaging
+++ b/packages/jumpbox/packaging
@@ -80,14 +80,25 @@ n=$((n + 1))
 # 26.1.2, which honors this env var (no-op on jammy's compile path).
 # packaging is vendored because wheel >= 0.46 declares it a runtime dependency;
 # get-pip installs wheel on jammy's python3.10, which fails offline without it.
+# --target (not --prefix): the stemcells' Debian-patched Python routes --prefix
+# installs to $PREFIX/local/{bin,lib} (posix_local scheme), off the jumpbox
+# PATH. --target keeps a flat, scheme-independent layout; the bin/ wrapper
+# sets PYTHONPATH so the S3 module resolves at runtime.
 (export PIP_BREAK_SYSTEM_PACKAGES=1
  python3 jumpbox/get-pip.py --no-index --find-links=jumpbox/wheels
  export PATH=$HOME/.local/bin:$PATH
  tar -xzvf jumpbox/s3cmd-2.4.0.tar.gz
  cd s3cmd-2.4.0
- pip install . --prefix=${BOSH_INSTALL_TARGET} \
+ pip install . --target=${BOSH_INSTALL_TARGET}/s3cmd \
    --no-index \
-   --find-links=../jumpbox/wheels) &
+   --find-links=../jumpbox/wheels
+ cat > ${BOSH_INSTALL_TARGET}/bin/s3cmd <<'WRAP'
+#!/bin/sh
+here="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+export PYTHONPATH="${here}/../s3cmd${PYTHONPATH:+:$PYTHONPATH}"
+exec /usr/bin/python3 "${here}/../s3cmd/bin/s3cmd" "$@"
+WRAP
+ chmod 0755 ${BOSH_INSTALL_TARGET}/bin/s3cmd) &
 n=$((n + 1))
 
 while [[ $n -gt 0 ]]; do


### PR DESCRIPTION
## Problem

The `testflight` job has been red since the inventory errand gained a `check s3cmd --version` step (0c529fc, May 29): every tool passes except s3cmd.

Root cause: the s3cmd install has been broken since it was introduced in #106. Ubuntu's Debian-patched Python (jammy and noble stemcells) routes `pip install --prefix=$X` through the `posix_local` scheme, so everything lands in `$X/local/bin` and `$X/local/lib/python3.N/dist-packages` — off the jumpbox PATH. Even with the script on PATH, the `S3` module is not on any runtime `sys.path`, so `s3cmd` dies with `ModuleNotFoundError: No module named 'S3'`. Nothing tested it before the errand check existed, which is why earlier builds were green.

## Fix

Install with `pip install --target=${BOSH_INSTALL_TARGET}/s3cmd` (a flat layout immune to the Debian scheme rerouting) and ship a thin `bin/s3cmd` wrapper that sets `PYTHONPATH` and execs the real script — the same wrapper pattern the packaging already uses for vim.

## Verification

- Ran the packaging stanza verbatim from this branch as an offline install against the same vendored wheel set (pip 26.1.2, setuptools 82.0.1, wheel 0.47.0, packaging 26.2, python-dateutil, python-magic, six) on an ubuntu 22.04 worker: the errand-equivalent `s3cmd --version` check passes.
- Confirmed the same install + wrapper approach on ubuntu 24.04 (noble) as well.
- Reproduced the failure mode both ways beforehand: `--prefix` yields `local/bin/s3cmd` with pip 25.0.1 **and** 26.1.2, and a PATH-only fix still fails on the missing `S3` module.