### PR TITLE
Fix blob-bump CI: dead cf URL, openbao assets, jq tags, concurrency

### DIFF
--- a/ci/pipelines/jobs-upstream.yml
+++ b/ci/pipelines/jobs-upstream.yml
@@ -1,6 +1,7 @@
 jobs:
   - name: genesis
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -67,6 +68,7 @@ jobs:
 
   - name: safe
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -135,6 +137,7 @@ jobs:
 
   - name: esuf
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -201,6 +204,7 @@ jobs:
 
   - name: cf
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -268,6 +272,7 @@ jobs:
 
   - name: cloudfoundry-utils
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -334,6 +339,7 @@ jobs:
 
   - name: bosh-backup-and-restore
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -399,6 +405,7 @@ jobs:
 
   - name: bosh-cli
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -464,6 +471,7 @@ jobs:
 
   - name: credhub-cli
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -534,6 +542,7 @@ jobs:
 
   - name: fly
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -603,6 +612,7 @@ jobs:
 
   - name: spruce
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -671,6 +681,7 @@ jobs:
           link:    (( grab meta.shout.links.build ))
   - name: uaa
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -742,6 +753,7 @@ jobs:
   # ---------------------------------------------------------------------------
   - name: certstrap
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -810,6 +822,7 @@ jobs:
 
   - name: jq
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -878,6 +891,7 @@ jobs:
 
   - name: shield
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -946,6 +960,7 @@ jobs:
 
   - name: yq
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -1014,6 +1029,7 @@ jobs:
 
   - name: opentofu
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }
@@ -1082,6 +1098,7 @@ jobs:
 
   - name: openbao
     public: true
+    serial_groups: [git-push]
     plan:
     - in_parallel:
       - { get: git }

--- a/ci/pipelines/jobs-upstream.yml
+++ b/ci/pipelines/jobs-upstream.yml
@@ -1107,9 +1107,13 @@ jobs:
         params:
           REPO_ROOT:        git
           REPO_OUT:         pushme
+          # openbao releases carry 300+ assets; the github-release resource
+          # only lists the first page, so the glob never matches. Fetch the
+          # tarball directly instead of relying on the asset download.
+          BLOB_SOURCE:      https://github.com/openbao/openbao/releases/download/v%s/bao_%s_Linux_x86_64.tar.gz
           BLOB_DIR:         openbao
           BLOB_NAME:        bao
-          BLOB_BINARY:      bao_*_Linux_x86_64.tar.gz
+          BLOB_BINARY:      bao_Linux_x86_64.tar.gz
           BLOB_DESTINATION: jumpbox/bins/bao
           BLOB_CLEANUP:     jumpbox/bins/bao
           AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))

--- a/ci/pipelines/jobs-upstream.yml
+++ b/ci/pipelines/jobs-upstream.yml
@@ -224,7 +224,7 @@ jobs:
           REPO_ROOT:        git
           REPO_OUT:         pushme
           RELEASE_DIR:      cf
-          BLOB_SOURCE:      https://cli.run.pivotal.io/stable?release=linux64-binary&version=%s&source=github-rel&x=.tgz
+          BLOB_SOURCE:      https://packages.cloudfoundry.org/stable?release=linux64-binary&version=%s&source=github-rel&x=.tgz
           BLOB_DIR:         cf
           BLOB_NAME:        cf
           BLOB_BINARY:      cf

--- a/ci/pipelines/resources.yml
+++ b/ci/pipelines/resources.yml
@@ -138,6 +138,9 @@ resources:
       user: jqlang
       repository: jq
       access_token: (( grab meta.github.access_token ))
+      # jq tags releases as "jq-1.8.2"; strip the prefix so version files,
+      # the downgrade guard, and commit messages see a bare version.
+      tag_filter: "jq-(.*)"
 
   - name: shield
     type: github-release

--- a/ci/pipelines/resources.yml
+++ b/ci/pipelines/resources.yml
@@ -86,7 +86,7 @@ resources:
   - name: bosh-backup-and-restore
     type: github-release
     source:
-      user: cloudfoundry-incubator
+      user: cloudfoundry
       repository: bosh-backup-and-restore
       access_token: (( grab meta.github.access_token ))
 
@@ -100,7 +100,7 @@ resources:
   - name: credhub-cli
     type: github-release
     source:
-      user: cloudfoundry-incubator
+      user: cloudfoundry
       repository: credhub-cli
       access_token: (( grab meta.github.access_token ))
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,7 +1,7 @@
 
 # jq
 
-- Bumped jq to vjq-1.8.2
+- Bumped jq to v1.8.2
 
 # yq
 

--- a/ci/scripts/update-blob
+++ b/ci/scripts/update-blob
@@ -65,15 +65,26 @@ if [[ -f "$VERSION_DB" ]]; then
 
   if [[ -n "$cur" && -n "$inc" ]]; then
     if [[ "$inc" == "$cur" ]]; then
-      header "Blob '${BLOB_NAME}' already at ${current_raw}; nothing to do."
-      cp -a "${REPO_ROOT}" "${REPO_OUT}"
-      exit 0
-    fi
-    highest="$(printf '%s\n%s\n' "$cur" "$inc" | sort -V | tail -1)"
-    if [[ "$highest" == "$cur" ]]; then
-      header "Refusing downgrade of '${BLOB_NAME}': have ${current_raw}, upstream offered ${VERSION}."
-      cp -a "${REPO_ROOT}" "${REPO_OUT}"
-      exit 0
+      # same numeric version: compare the raw strings so pre-release
+      # bumps (1.7.0-beta-8 -> 1.7.0-beta-9) still go through
+      if [[ "$VERSION" == "$current_raw" ]]; then
+        header "Blob '${BLOB_NAME}' already at ${current_raw}; nothing to do."
+        cp -a "${REPO_ROOT}" "${REPO_OUT}"
+        exit 0
+      fi
+      highest_raw="$(printf '%s\n%s\n' "$current_raw" "$VERSION" | sort -V | tail -1)"
+      if [[ "$highest_raw" == "$current_raw" ]]; then
+        header "Refusing downgrade of '${BLOB_NAME}': have ${current_raw}, upstream offered ${VERSION}."
+        cp -a "${REPO_ROOT}" "${REPO_OUT}"
+        exit 0
+      fi
+    else
+      highest="$(printf '%s\n%s\n' "$cur" "$inc" | sort -V | tail -1)"
+      if [[ "$highest" == "$cur" ]]; then
+        header "Refusing downgrade of '${BLOB_NAME}': have ${current_raw}, upstream offered ${VERSION}."
+        cp -a "${REPO_ROOT}" "${REPO_OUT}"
+        exit 0
+      fi
     fi
   fi
 fi

--- a/ci/scripts/update-blob
+++ b/ci/scripts/update-blob
@@ -109,8 +109,8 @@ fi
 ######
 if [[ ${BLOB_SOURCE:-} =~ ^http ]]; then
   header "Fetching blobs from upstream"
-  # shellcheck disable=SC2059
-  BLOB_SRC_URL="$(printf "${BLOB_SOURCE}" "${VERSION}")"
+  # substitute every %s so URLs may embed the version more than once
+  BLOB_SRC_URL="${BLOB_SOURCE//%s/${VERSION}}"
   echo "Fetching blob from upstream $BLOB_SRC_URL ..."
   if [[ ${BLOB_SOURCE} =~ .tgz$ ]]; then
     curl -Lsk "$BLOB_SRC_URL" | tar -xzO "${BLOB_SRC_BINARY:-"$BLOB_BINARY"}" > "../${BLOB_DIR}/${BLOB_BINARY}"

--- a/ci/scripts/update-blob
+++ b/ci/scripts/update-blob
@@ -147,6 +147,14 @@ if [[ ${BLOB_DIR}/${BLOB_BINARY} == *".tgz" || ${BLOB_DIR}/${BLOB_BINARY} == *".
   echo "Unpacking TarGz"
   tar zxvf ../${BLOB_DIR}/${BLOB_BINARY} -C ../${BLOB_DIR}
   bosh add-blob ../${BLOB_DIR}/${BLOB_NAME} "${blob_dst}"
+elif [[ ${BLOB_DIR}/${BLOB_BINARY} == *".zip" ]]; then
+  echo "Unpacking Zip"
+  # BLOB_INNER: path (or glob) of the wanted binary inside the archive,
+  # for upstreams whose binary name differs from the blob name
+  unzip -o ../${BLOB_DIR}/${BLOB_BINARY} -d ../${BLOB_DIR}
+  for blob_src in ../${BLOB_DIR}/${BLOB_INNER:-${BLOB_NAME}}; do
+    bosh add-blob "${blob_src}" "${blob_dst}"
+  done
 elif [[ "$BLOB_BINARY" == "*" ]]; then
   for blob_src in ../${BLOB_DIR}/${BLOB_BINARY}; do
     base=${blob_src##*/}

--- a/ci/version_control.yml
+++ b/ci/version_control.yml
@@ -8,7 +8,7 @@ credhub: 2.9.58
 esuf: 0.1.2
 fly: 8.2.4
 genesis: 3.0.14
-jq: jq-1.8.2
+jq: 1.8.2
 safe: 1.9.0
 shield: 9.0.1
 spruce: 1.35.12


### PR DESCRIPTION
Fixes the blob-bump CI problems triaged in #115.

## What's here

- **cf**: download from `packages.cloudfoundry.org` — `cli.run.pivotal.io` is dead (empty responses), which is what has been failing the cf8 job since July 2 (the `/etc/ssl/certs/bundleXXXXXX` message in those logs is non-fatal noise that appears in every blob job).
- **openbao**: fetch the release tarball directly by URL. openbao releases carry 300+ assets and the github-release resource only lists the first page, so the asset glob never matches. `update-blob` now substitutes every `%s` in `BLOB_SOURCE` so the URL can embed the version twice.
- **jq**: `tag_filter: "jq-(.*)"` so jq's `jq-1.8.2`-style tags stop polluting recorded versions; repairs the `jq: jq-1.8.2` entry and `vjq-1.8.2` release-notes line from the first bump run.
- **serial_groups**: all blob jobs share one serial group — every job rewrites the same three files, so concurrent triggers failed the final git put with a rebase conflict (seen with yq + opentofu).
- **bbr / credhub-cli**: track the `cloudfoundry` org; both repos left `cloudfoundry-incubator` and only resolve via redirect today.
- **downgrade guard**: compare full version strings when numeric cores match, so pre-release bumps (`1.7.0-beta-8` → `1.7.0-beta-9`) go through instead of no-oping.
- **zip support**: `update-blob` can unpack zip blobs, with `BLOB_INNER` naming the binary inside the archive when it differs from the blob name.

The last two exist to support the maintained-successor adoptions (spiff++, natscli) in the companion `adopt-spiff-natscli` PR.

## After merge

Repipe. The deployed pipeline is one repipe behind main and still runs the removed `cf7`/`cf8` jobs; repiping applies these fixes and retires those jobs.
