### PR TITLE
Adopt spiff++ and natscli as maintained upstreams

### DIFF
--- a/ci/pipelines/jobs-upstream.yml
+++ b/ci/pipelines/jobs-upstream.yml
@@ -1220,3 +1220,77 @@ jobs:
           message: blob ingestion job '$BUILD_JOB_NAME' failed.
           ok:      no
           link:    (( grab meta.shout.links.build ))
+
+  # natscli (nats-io/natscli): manually-gated like the other blob jobs.
+  # No version_control.yml seed on purpose: natscli restarts versioning at
+  # 0.x, below the legacy client's 1.0.2, so a seed would read as a
+  # downgrade; the first run records its version instead.
+  - name: nats
+    public: true
+    serial_groups: [git-push]
+    plan:
+    - in_parallel:
+      - { get: git }
+      - get: nats
+        params:
+          globs:
+          - nats-*-linux-amd64.zip
+    - task: update-nats
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: (( grab meta.image.name ))
+            tag:        (( grab meta.image.tag ))
+        inputs:
+        - name: git
+        - name: nats
+        outputs:
+        - name: pushme
+        run:
+          path: ./git/ci/scripts/update-blob
+        params:
+          REPO_ROOT:        git
+          REPO_OUT:         pushme
+          BLOB_DIR:         nats
+          BLOB_NAME:        nats
+          BLOB_BINARY:      nats-*-linux-amd64.zip
+          BLOB_INNER:       nats-*/nats
+          BLOB_DESTINATION: jumpbox/bins/nats
+          BLOB_CLEANUP:     jumpbox/bins/nats
+          AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))
+          AWS_SECRET_KEY:   (( grab meta.aws.secret_key ))
+          BRANCH:           (( grab meta.github.branch ))
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+    - put: git
+      params:
+        rebase: true
+        repository: pushme/git
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))

--- a/ci/pipelines/jobs-upstream.yml
+++ b/ci/pipelines/jobs-upstream.yml
@@ -1147,3 +1147,76 @@ jobs:
           message: blob ingestion job '$BUILD_JOB_NAME' failed.
           ok:      no
           link:    (( grab meta.shout.links.build ))
+
+  # spiff++ (mandelsoft/spiff): manually-gated like the other blob jobs.
+  # NOTE: requires the zip support and pre-release downgrade-guard handling
+  # in ci/scripts/update-blob before this job is triggered.
+  - name: spiff
+    public: true
+    serial_groups: [git-push]
+    plan:
+    - in_parallel:
+      - { get: git }
+      - get: spiff
+        params:
+          globs:
+          - spiff_linux_amd64.zip
+    - task: update-spiff
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: (( grab meta.image.name ))
+            tag:        (( grab meta.image.tag ))
+        inputs:
+        - name: git
+        - name: spiff
+        outputs:
+        - name: pushme
+        run:
+          path: ./git/ci/scripts/update-blob
+        params:
+          REPO_ROOT:        git
+          REPO_OUT:         pushme
+          BLOB_DIR:         spiff
+          BLOB_NAME:        spiff
+          BLOB_BINARY:      spiff_linux_amd64.zip
+          BLOB_INNER:       spiff++
+          BLOB_DESTINATION: jumpbox/bins/spiff
+          BLOB_CLEANUP:     jumpbox/bins/spiff
+          AWS_ACCESS_KEY:   (( grab meta.aws.access_key ))
+          AWS_SECRET_KEY:   (( grab meta.aws.secret_key ))
+          BRANCH:           (( grab meta.github.branch ))
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))
+    - put: git
+      params:
+        rebase: true
+        repository: pushme/git
+      on_success:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' succeeded.
+          ok:      yes
+          link:    (( grab meta.shout.links.build ))
+      on_failure:
+        put: notify
+        params:
+          topic:   (( concat meta.shout.topic "-$BUILD_JOB_NAME" ))
+          message: blob ingestion job '$BUILD_JOB_NAME' failed.
+          ok:      no
+          link:    (( grab meta.shout.links.build ))

--- a/ci/pipelines/resources.yml
+++ b/ci/pipelines/resources.yml
@@ -174,3 +174,11 @@ resources:
       user: mandelsoft
       repository: spiff
       access_token: (( grab meta.github.access_token ))
+
+  # natscli, the supported successor of the legacy nats pub/sub client
+  - name: nats
+    type: github-release
+    source:
+      user: nats-io
+      repository: natscli
+      access_token: (( grab meta.github.access_token ))

--- a/ci/pipelines/resources.yml
+++ b/ci/pipelines/resources.yml
@@ -166,3 +166,11 @@ resources:
       user: openbao
       repository: openbao
       access_token: (( grab meta.github.access_token ))
+
+  # spiff++, the maintained fork of the archived cloudfoundry-incubator/spiff
+  - name: spiff
+    type: github-release
+    source:
+      user: mandelsoft
+      repository: spiff
+      access_token: (( grab meta.github.access_token ))

--- a/ci/version_control.yml
+++ b/ci/version_control.yml
@@ -11,6 +11,7 @@ genesis: 3.0.14
 jq: jq-1.8.2
 safe: 1.9.0
 shield: 9.0.1
+spiff: 1.0.8
 spruce: 1.35.12
 tofu: 1.12.4
 uaa: 0.20.2

--- a/jobs/inventory/templates/bin/run
+++ b/jobs/inventory/templates/bin/run
@@ -35,7 +35,7 @@ check safe version
 check esuf --version
 check shield -v
 check spruce --version
-check spiff -v
+check spiff --version
 check uaa version
 
 # secrets / infrastructure


### PR DESCRIPTION
Replaces the two dead-upstream tools identified in #115 with their maintained successors, wired into the same manually-gated bump-job pattern as the rest of the blob jobs.

## spiff → spiff++

`cloudfoundry-incubator/spiff` has been archived since 2017 (last release v1.0.8, Jan 2017). The maintained fork [`mandelsoft/spiff`](https://github.com/mandelsoft/spiff) (spiff++) is a drop-in replacement; its releases are all `1.7.0-beta-N` zips containing a `spiff++` binary, installed here under the existing `spiff` name. The inventory check moves from `spiff -v` to `spiff --version`, which the legacy CLI and spiff++ both accept, so the errand passes before and after the blob swap.

## nats → natscli

The bundled `nats` blob is the legacy 1.0.2 pub/sub client whose upstream is long gone. The supported `nats` command is [`nats-io/natscli`](https://github.com/nats-io/natscli) (checked `nats-release` first — it only carries server-side packages, no CLI). No `version_control.yml` seed on purpose: natscli restarts versioning at 0.x, below the legacy 1.0.2, so a seed would read as a downgrade; the first bump run records its version. The inventory errand already calls `nats --version`, which natscli understands.

## Dependency

Mergeable independently of #116, but **do not trigger the new `spiff`/`nats` jobs until #116 is merged and repiped** — they rely on its `update-blob` zip support (both) and pre-release downgrade-guard handling (spiff).
