### PR TITLE
Fix pipeline validation errors found on repipe

### DIFF
--- a/ci/pipelines/base.yml
+++ b/ci/pipelines/base.yml
@@ -95,3 +95,5 @@ groups:
     - yq
     - opentofu
     - openbao
+    - spiff
+    - nats

--- a/ci/pipelines/jobs-upstream.yml
+++ b/ci/pipelines/jobs-upstream.yml
@@ -685,7 +685,7 @@ jobs:
     plan:
     - in_parallel:
       - { get: git }
-      - { get: uaa-cli, trigger: true }
+      - { get: uaa, trigger: true }
     - task: update-uaa-cli
       config:
         platform: linux


### PR DESCRIPTION
Applying #116/#117 via `fly set-pipeline` surfaced two validation errors that only appear at repipe time:

- The **uaa** job does `get: uaa-cli` but the resource is named `uaa` — pre-existing since #110, unnoticed because the pipeline was never repiped after that change (the deployed config still uses `get: uaa`, matching the task input and blob params).
- The new **spiff**/**nats** jobs from #117 belonged to no group; Concourse rejects a config where any job is groupless once groups are in use. Added both to the `blobs` group.

The merged config now passes `fly validate-pipeline`. Repipe after merging.